### PR TITLE
Change assessment of most

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ Halbert)
 see it in newer systems anymore.
 
 [most](http://www.jedsoft.org/most/) - multiple windows, can scroll left and
-right. (John E Davis) (inactive, last release in 2007)
+right. (John E Davis) (barely active)
 
 
 ### different application of related ideas


### PR DESCRIPTION
It seems there is again some development in `most`. A new release (5.1) was published in February 2019 and a new unstable version (most-pre5.2-2) was published in January 2020.

Therefore weaken the claim that it is inactive.